### PR TITLE
Fix ValueError in AI Rebalancing page

### DIFF
--- a/app.py
+++ b/app.py
@@ -428,7 +428,7 @@ def ai_rebalancing():
     # Show current vs target allocation
     allocation_df = pd.DataFrame({
         'Asset Class': list(portfolio['allocation'].keys()),
-        'Current %': [25, 35, 20, 15, 5],  # Mock current allocation
+        'Current %': [25, 35, 20, 15, 5, 0],  # Mock current allocation
         'Target %': list(portfolio['allocation'].values())
     })
     


### PR DESCRIPTION
The `ai_rebalancing` function was attempting to create a pandas DataFrame with columns of unequal length. The `'Current %'` column was hardcoded with a list of 5 elements, while the other columns were derived from the portfolio's allocation, which has 6 asset classes. This mismatch caused a `ValueError` when the page was loaded.

This change corrects the length of the hardcoded list to 6 elements, ensuring that all columns in the DataFrame have the same length and preventing the `ValueError`.